### PR TITLE
icons: use percentage

### DIFF
--- a/_static/theme_overrides.css
+++ b/_static/theme_overrides.css
@@ -11,3 +11,9 @@
       overflow: visible !important;
    }
 }
+
+/* Custom styles for icon column of the API table */
+#omero-application-programming-interfaces td:nth-child(1) {
+   padding: 5px;
+   min-width: 40px;
+}

--- a/api_usage.rst
+++ b/api_usage.rst
@@ -7,7 +7,7 @@ use a combination of Jupyter notebook and scripts to demonstrate how to use the 
 
 
 .. list-table::
-   :widths: 20 20 50
+   :widths: 25 25 50
 
    * - \ |java|_
      - :doc:`java/docs/index`
@@ -31,20 +31,16 @@ use a combination of Jupyter notebook and scripts to demonstrate how to use the 
          :end-before: Contents
 
 .. |r| image:: images/logos/r.png
-   :width: 1.04167in
-   :height: 1.04167in
+   :width: 100%
 
 .. |matlab| image:: images/logos/matlab.png
-   :width: 1.04167in
-   :height: 1.04167in
+   :width: 100%
 
 .. |python| image:: images/logos/python.png
-   :width: 1.04167in
-   :height: 1.04167in
+   :width: 100%
 
 .. |java| image:: images/logos/java.png
-   :width: 1.04167in
-   :height: 1.04167in
+   :width: 100%
 
 
 .. toctree::

--- a/api_usage.rst
+++ b/api_usage.rst
@@ -31,20 +31,20 @@ use a combination of Jupyter notebook and scripts to demonstrate how to use the 
          :end-before: Contents
 
 .. |r| image:: images/logos/r.png
-   :width: 30px
-   :height: 30px
+   :width: 3em
+   :height: 2em
 
 .. |matlab| image:: images/logos/matlab.png
-   :width: 30px
-   :height: 30px
+   :width: 3em
+   :height: 2em
 
 .. |python| image:: images/logos/python.png
-   :width: 30px
-   :height: 30px
+   :width: 3em
+   :height: 2em
 
 .. |java| image:: images/logos/java.png
-   :width: 30px
-   :height: 30px
+   :width: 3em
+   :height: 2em
 
 
 .. toctree::

--- a/api_usage.rst
+++ b/api_usage.rst
@@ -31,16 +31,20 @@ use a combination of Jupyter notebook and scripts to demonstrate how to use the 
          :end-before: Contents
 
 .. |r| image:: images/logos/r.png
-   :width: 100%
+   :width: 30px
+   :height: 30px
 
 .. |matlab| image:: images/logos/matlab.png
-   :width: 100%
+   :width: 30px
+   :height: 30px
 
 .. |python| image:: images/logos/python.png
-   :width: 100%
+   :width: 30px
+   :height: 30px
 
 .. |java| image:: images/logos/java.png
-   :width: 100%
+   :width: 30px
+   :height: 30px
 
 
 .. toctree::

--- a/api_usage.rst
+++ b/api_usage.rst
@@ -31,20 +31,13 @@ use a combination of Jupyter notebook and scripts to demonstrate how to use the 
          :end-before: Contents
 
 .. |r| image:: images/logos/r.png
-   :width: 3em
-   :height: 2em
 
 .. |matlab| image:: images/logos/matlab.png
-   :width: 3em
-   :height: 2em
 
 .. |python| image:: images/logos/python.png
-   :width: 3em
-   :height: 2em
 
 .. |java| image:: images/logos/java.png
-   :width: 3em
-   :height: 2em
+
 
 
 .. toctree::


### PR DESCRIPTION
The logos appear smaller but they are not squashed
<img width="909" alt="Screenshot 2020-05-12 at 11 55 08" src="https://user-images.githubusercontent.com/1022396/81680027-96665100-944a-11ea-9c6d-7e5ced2ea3c3.png">
