### PR TITLE
Improve the former "training-example"

### DIFF
--- a/example.rst
+++ b/example.rst
@@ -1,13 +1,17 @@
-Training example
-================
+OMERO walkthrough example
+=========================
 
-In this document, we go through a common workflow that a scientist wishing to use OMERO will follow:
+In this document, we go through a common workflow that a scientist wishing to use OMERO might follow:
 
  * Import data using the Desktop client.
- * View images using the OMERO.iviewer plugin
- * Analyze images using a 3rd party tool e.g. Fiji.
+ * View images using the OMERO.iviewer plugin.
+ * Analyze images using a 3rd party tool, e.g. Fiji.
  * Generate a figure using OMERO.figure.
 
+
+
+Import
+------
 
 :doc:`upload/docs/import-desktop-client`
 
@@ -16,6 +20,8 @@ In this document, we go through a common workflow that a scientist wishing to us
     :start-line: 3
     :end-before: Setup
 
+View
+----
 
 :doc:`iviewer/docs/iviewer`
 
@@ -23,12 +29,17 @@ In this document, we go through a common workflow that a scientist wishing to us
     :start-line: 3
     :end-before: Resources
 
+Analyze
+-------
+
 :doc:`fiji/docs/manual_analysis`
 
 .. include:: fiji/docs/manual_analysis.rst
     :start-line: 3
     :end-before: **Setup
 
+Present or publish data
+-----------------------
 
 :doc:`figure/docs/omero_figure`
 

--- a/index.rst
+++ b/index.rst
@@ -7,7 +7,7 @@ To learn more about OMERO, we recommend that you first visit `https://www.openmi
 Getting started
 ---------------
 
-:doc:`example` combines a step-by-step example workflow from import to figure creation.
+:doc:`example` presents a step-by-step example of a typical OMERO user workflow from import to figure creation.
 
 
 General


### PR DESCRIPTION
As discussed, renaming the training-example and adding headers (was hard to read as the sections started with unformatted links).

Failed to build it locally, as the repo does not have a subfolder ``docs``, and the main directory does not contain sphinx specs.

cc @jburel @will-moore 