### PR TITLE
Change formulation (remove "section"), change import link to upload link

### DIFF
--- a/core_features.rst
+++ b/core_features.rst
@@ -1,11 +1,11 @@
 General concepts
 ================
 
-In this section we introduce general concepts about OMERO: data import, management, annotation, search, etc..
+Here we introduce general concepts about OMERO: data import, management, annotation, search, etc..
 
-- :doc:`upload/docs/import`
+- :doc:`upload/docs/index`
 
-.. include:: upload/docs/import.rst
+.. include:: upload/docs/index.rst
     :start-line: 3
     :end-before: Contents
 

--- a/core_features.rst
+++ b/core_features.rst
@@ -1,7 +1,7 @@
 General concepts
 ================
 
-Here we introduce general concepts about OMERO: data import, management, annotation, search, etc..
+Here we introduce general concepts about OMERO: image import, metadata upload, management, annotation, search and server-side scripts.
 
 - :doc:`upload/docs/index`
 


### PR DESCRIPTION
See https://github.com/ome/omero-guides/issues/47 for motivation.

Suggesting here to point in "General concepts" to the whole upload chapter, instead of pointing directly to "import" sub-chapter, which was bypassing the metadata upload walkthrough.

