### PR TITLE
Fix reference to Setup in example walkthrough

### DIFF
--- a/example.rst
+++ b/example.rst
@@ -53,4 +53,4 @@ Present or publish data
 
 .. include:: figure/docs/omero_figure.rst
     :start-line: 3
-    :end-before: **Setup
+    :end-before: Setup


### PR DESCRIPTION
Fixes warning spotted in https://github.com/ome/omero-guides/issues/56

cc @joshmoore 